### PR TITLE
Slam piece event listener

### DIFF
--- a/Frontend/EventListeners.js
+++ b/Frontend/EventListeners.js
@@ -3,7 +3,7 @@ import { shiftPieceDown, printBoard, game} from " ./GameLogic.js";
 console.log("EventListeners.js")
 
 addEventListener("keydown", function(event) {
-    if (keydown === "Space"){
+    if (event.code === "Space"){
        while (game.activePiece != null) {
         shiftPieceDown();  
        }


### PR DESCRIPTION
Slam eventlistener uses spacebar to move piece to the bottom. 

This method works - - errors in shiftPieceDown need to be fixed for testing