### PR TITLE
Persist per-piece colors when minos lock

### DIFF
--- a/Frontend/GameLogic.js
+++ b/Frontend/GameLogic.js
@@ -74,7 +74,8 @@ export function spawnPiece(tetrominoKey) {
       for (let j = 0; j < 4; j++) {
         // Inner loop for columns
         if (game.activePiece.shape[game.activePiece.rot][i][j] === 1) {
-          game.board[i + game.activePiece.row][j + game.activePiece.col] = 1;
+          game.board[i + game.activePiece.row][j + game.activePiece.col] =
+            game.activePiece.id;
         }
       }
     }
@@ -163,7 +164,7 @@ export function rotatePiece() {
     for (let i = 0; i < 4; i++) {
       for (let j = 0; j < 4; j++) {
         if (shape[game.activePiece.rot][i][j] === 1) {
-          game.board[row + i][col + j] = 1;
+          game.board[row + i][col + j] = game.activePiece.id;
         }
       }
     }
@@ -174,7 +175,8 @@ export function rotatePiece() {
   for (let i = 0; i < 4; i++) {
     for (let j = 0; j < 4; j++) {
       if (shape[game.activePiece.rot][i][j] === 1) {
-        game.board[game.activePiece.row + i][game.activePiece.col + j] = 1;
+        game.board[game.activePiece.row + i][game.activePiece.col + j] =
+            game.activePiece.id;
       }
     }
   }
@@ -221,7 +223,8 @@ export function shiftPieceDown() {
       for (let i = 0; i < 4; i++) {
         for (let j = 0; j < 4; j++) {
           if (game.activePiece.shape[game.activePiece.rot][i][j] === 1)
-            game.board[game.activePiece.row + i][game.activePiece.col + j] = 1;
+            game.board[game.activePiece.row + i][game.activePiece.col + j] =
+            game.activePiece.id;
         }
       }
       game.activePiece = null;
@@ -237,7 +240,8 @@ export function shiftPieceDown() {
     for (let i = 0; i < 4; i++) {
       for (let j = 0; j < 4; j++) {
         if (game.activePiece.shape[game.activePiece.rot][i][j] === 1) {
-          game.board[game.activePiece.row + i][game.activePiece.col + j] = 1;
+          game.board[game.activePiece.row + i][game.activePiece.col + j] =
+            game.activePiece.id;
         }
       }
     }
@@ -256,7 +260,8 @@ export function shiftPieceDown() {
   for (let i = 0; i < 4; i++) {
     for (let j = 0; j < 4; j++) {
       if (game.activePiece.shape[game.activePiece.rot][i][j] === 1)
-        game.board[game.activePiece.row + i][game.activePiece.col + j] = 1;
+        game.board[game.activePiece.row + i][game.activePiece.col + j] =
+            game.activePiece.id;
     }
   }
   return 1;
@@ -322,7 +327,7 @@ export function solidifyPiece() {
       if (y >= 20 || x < 0 || x >= 10) return true;
 
       // collision with settled blocks (with your current single-layer board)
-      if (game.board[y][x] === 1) return true;
+      if (game.board[y][x] !== 0) return true;
     }
   }
   return false; // safe to move down
@@ -373,7 +378,8 @@ export function shiftPieceLeft() {
   for (let i = 0; i < 4; i++) {
     for (let j = 0; j < 4; j++) {
       if (game.activePiece.shape[game.activePiece.rot][i][j] === 1) {
-        game.board[i + game.activePiece.row][j + game.activePiece.col] = 1;
+        game.board[i + game.activePiece.row][j + game.activePiece.col] =
+            game.activePiece.id;
       }
     }
   }
@@ -400,7 +406,7 @@ function isAgainstPieceLeft(leftCells) {
   leftCells.forEach((cell) => {
     let boardRow = game.activePiece.row + cell.r;
     let boardColumn = game.activePiece.col + cell.c;
-    if (game.board[boardRow][boardColumn - 1] === 1) {
+    if (game.board[boardRow][boardColumn - 1] !== 0) {
       isAgainstPieceLeft = true;
     }
   });
@@ -433,7 +439,8 @@ export function shiftPieceRight() {
   for (let i = 0; i < 4; i++) {
     for (let j = 0; j < 4; j++) {
       if (game.activePiece.shape[game.activePiece.rot][i][j] === 1) {
-        game.board[i + game.activePiece.row][j + game.activePiece.col] = 1;
+        game.board[i + game.activePiece.row][j + game.activePiece.col] =
+            game.activePiece.id;
       }
     }
   }
@@ -557,7 +564,7 @@ function isAgainstPieceRight(leftCells) {
     let boardRow = game.activePiece.row + cell.r;
     let boardColumn = game.activePiece.col + cell.c;
     if (boardColumn + 1 > width - 1) return;
-    if (game.board[boardRow][boardColumn + 1] === 1) {
+    if (game.board[boardRow][boardColumn + 1] !== 0) {
       isAgainstPieceRight = true;
     }
   });

--- a/Frontend/GameLoop.js
+++ b/Frontend/GameLoop.js
@@ -16,79 +16,84 @@ export function paintBoard() {
   for (let i = 0; i < 20; i++) {
     for (let j = 0; j < 10; j++) {
       if (game.board[i][j] === 0) {
+        cells[i][j].className = "cell";
         cells[i][j].style.backgroundColor = "transparent";
       }
     }
   }
 
   // piece shadow
-  // calculate how far the whole piece can drop
-  let dropDistance = 0;
-  let collision = false;
+  if (game.activePiece) {
+    let dropDistance = 0;
+    let collision = false;
 
-  while (!collision) {
+    while (!collision) {
+      for (let i = 0; i < 4; i++) {
+        for (let j = 0; j < 4; j++) {
+          if (game.activePiece.shape[game.activePiece.rot][i][j] === 1) {
+            let newRow = game.activePiece.row + i + dropDistance + 1;
+            let newCol = game.activePiece.col + j;
+
+            // check if this position is part of the active piece's current position
+            let isPartOfActivePiece = false;
+            for (let x = 0; x < 4; x++) {
+              for (let y = 0; y < 4; y++) {
+                if (
+                  game.activePiece.shape[game.activePiece.rot][x][y] === 1 &&
+                  game.activePiece.row + x === newRow &&
+                  game.activePiece.col + y === newCol
+                ) {
+                  isPartOfActivePiece = true;
+                }
+              }
+            }
+
+            // if newRow is out of bounds or collides with a filled cell that isn't part of the active piece, we have a collision
+            if (
+              newRow >= 20 ||
+              (newRow >= 0 &&
+                game.board[newRow][newCol] !== 0 &&
+                !isPartOfActivePiece)
+            ) {
+              collision = true;
+              break;
+            }
+          }
+        }
+        if (collision) break;
+      }
+
+      if (!collision) dropDistance++;
+    }
+
+    // paint shadow using final drop distance
     for (let i = 0; i < 4; i++) {
       for (let j = 0; j < 4; j++) {
         if (game.activePiece.shape[game.activePiece.rot][i][j] === 1) {
-          let newRow = game.activePiece.row + i + dropDistance + 1;
-          let newCol = game.activePiece.col + j;
+          const shadowRow = game.activePiece.row + i + dropDistance;
+          const shadowCol = game.activePiece.col + j;
 
-          // check if this position is part of the active piece's current position
-          let isPartOfActivePiece = false;
-          for (let x = 0; x < 4; x++) {
-            for (let y = 0; y < 4; y++) {
-              if (
-                game.activePiece.shape[game.activePiece.rot][x][y] === 1 &&
-                game.activePiece.row + x === newRow &&
-                game.activePiece.col + y === newCol
-              ) {
-                isPartOfActivePiece = true;
-              }
-            }
-          }
-
-          // if newRow is out of bounds or collides with a filled cell that isn't part of the active piece, we have a collision
           if (
-            newRow >= 20 ||
-            (newRow >= 0 &&
-              game.board[newRow][newCol] === 1 &&
-              !isPartOfActivePiece)
+            shadowRow >= 0 &&
+            shadowRow < 20 &&
+            shadowCol >= 0 &&
+            shadowCol < 10
           ) {
-            collision = true;
-            break;
+            cells[shadowRow][shadowCol].style.backgroundColor = "var(--shadow)";
           }
         }
       }
-      if (collision) break;
-    }
-
-    if (!collision) dropDistance++;
-  }
-
-  // paint shadow using final drop distance
-  for (let i = 0; i < 4; i++) {
-    for (let j = 0; j < 4; j++) {
-      if (game.activePiece.shape[game.activePiece.rot][i][j] === 1) {
-        const shadowRow = game.activePiece.row + i + dropDistance;
-        const shadowCol = game.activePiece.col + j;
-
-        if (
-          shadowRow >= 0 &&
-          shadowRow < 20 &&
-          shadowCol >= 0 &&
-          shadowCol < 10
-        ) {
-          cells[shadowRow][shadowCol].style.backgroundColor = "var(--shadow)";
-        }
-      }
     }
   }
 
-  // pieces
+  // pieces (per-shape colors: board stores piece id 1–7 per cell)
   for (let i = 0; i < 20; i++) {
     for (let j = 0; j < 10; j++) {
-      if (game.board[i][j] === 1) {
-        cells[i][j].style.backgroundColor = "var(--filled)";
+      const v = game.board[i][j];
+      if (v !== 0) {
+        const el = cells[i][j];
+        el.style.backgroundColor = "";
+        el.className = `cell filled piece-${v}`;
       }
     }
   }
@@ -109,20 +114,16 @@ function tick() {
   paintBoard();
 }
 
-
-
 let gameInterval = setInterval(tick, 200);
 
 //pause and resume functions
 export function pauseGame() {
   clearInterval(gameInterval);
-  document.getElementById('pausePopup').classList.remove('hidden')
-  renderHighScores(document.getElementById('pausePopup').querySelector('ol'));
+  document.getElementById("pausePopup").classList.remove("hidden");
+  renderHighScores(document.getElementById("pausePopup").querySelector("ol"));
 }
 
 export function resumeGame() {
-  document.getElementById('pausePopup').classList.add('hidden')
+  document.getElementById("pausePopup").classList.add("hidden");
   gameInterval = setInterval(tick, 200);
 }
-
-

--- a/Frontend/index.css
+++ b/Frontend/index.css
@@ -9,6 +9,29 @@
   --gap: 2px;
   --cols: 10;
   --rows: 20;
+
+  /* Minos — board stores piece id per cell; ids match Pieces.js: 1=I 2=O 3=T 4=S 5=Z 6=J 7=L */
+  --piece-1-light: #6ee7ff;
+  --piece-1-dark: #0891b2;
+  --piece-1-glow: rgba(8, 145, 178, 0.5);
+  --piece-2-light: #fde047;
+  --piece-2-dark: #ca8a04;
+  --piece-2-glow: rgba(202, 138, 4, 0.45);
+  --piece-3-light: #c084fc;
+  --piece-3-dark: #7e22ce;
+  --piece-3-glow: rgba(126, 34, 206, 0.45);
+  --piece-4-light: #4ade80;
+  --piece-4-dark: #15803d;
+  --piece-4-glow: rgba(21, 128, 61, 0.45);
+  --piece-5-light: #fb7185;
+  --piece-5-dark: #be123c;
+  --piece-5-glow: rgba(190, 18, 60, 0.45);
+  --piece-6-light: #60a5fa;
+  --piece-6-dark: #1d4ed8;
+  --piece-6-glow: rgba(29, 78, 216, 0.45);
+  --piece-7-light: #fb923c;
+  --piece-7-dark: #c2410c;
+  --piece-7-glow: rgba(194, 65, 12, 0.45);
 }
 
 * {
@@ -94,11 +117,48 @@ body {
     rgba(255, 255, 255, 0) 40%
   );
 }
-.cell.filled {
-  background: linear-gradient(145deg, var(--filled), #2aa1ff);
+/* Filled cells — one rule per shape (edit --piece-N-* in :root) */
+.cell.filled.piece-1 {
+  background: linear-gradient(145deg, var(--piece-1-light), var(--piece-1-dark));
   box-shadow:
     inset 0 2px 6px rgba(0, 0, 0, 0.5),
-    0 0 8px rgba(90, 209, 255, 0.45);
+    0 0 8px var(--piece-1-glow);
+}
+.cell.filled.piece-2 {
+  background: linear-gradient(145deg, var(--piece-2-light), var(--piece-2-dark));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.5),
+    0 0 8px var(--piece-2-glow);
+}
+.cell.filled.piece-3 {
+  background: linear-gradient(145deg, var(--piece-3-light), var(--piece-3-dark));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.5),
+    0 0 8px var(--piece-3-glow);
+}
+.cell.filled.piece-4 {
+  background: linear-gradient(145deg, var(--piece-4-light), var(--piece-4-dark));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.5),
+    0 0 8px var(--piece-4-glow);
+}
+.cell.filled.piece-5 {
+  background: linear-gradient(145deg, var(--piece-5-light), var(--piece-5-dark));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.5),
+    0 0 8px var(--piece-5-glow);
+}
+.cell.filled.piece-6 {
+  background: linear-gradient(145deg, var(--piece-6-light), var(--piece-6-dark));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.5),
+    0 0 8px var(--piece-6-glow);
+}
+.cell.filled.piece-7 {
+  background: linear-gradient(145deg, var(--piece-7-light), var(--piece-7-dark));
+  box-shadow:
+    inset 0 2px 6px rgba(0, 0, 0, 0.5),
+    0 0 8px var(--piece-7-glow);
 }
 
 .hud {


### PR DESCRIPTION
Store tetromino id in board cells (1-7) so locked blocks keep shape colors. Update collision checks for non-zero occupancy. Paint cells from board id; remove settled-only styling.

Made-with: Cursor